### PR TITLE
Add ARM64 Docker image support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,11 @@ builds:
 - env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  goos:
+    - linux
+  goarch:
+    - amd64
+    - arm64
   ldflags:
     - -s -w -X github.com/rb3ckers/trafficmirror.Version={{.Version}}
     - -X github.com/rb3ckers/trafficmirror.Commit={{.Commit}}
@@ -31,14 +36,41 @@ dockers:
   - goos: linux
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
+    use: buildx
     build_flag_templates:
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     image_templates:
-      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:latest"
-      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:latest"
-      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}"
-      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Major }}"
-      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Major }}.{{ .Minor }}"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-amd64"
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-arm64"
+docker_manifests:
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:latest"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Major }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Tag }}-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 # Builder #
 ###########
 
-FROM golang:1.21-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH
 
 RUN apk add --no-cache git
 
@@ -11,9 +14,7 @@ COPY . /build
 WORKDIR /build
 
 RUN set -ex \
-    && GOOS=linux GOARCH=amd64 go build -o /build/trafficmirror
-
-RUN /build/trafficmirror --help
+    && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -o /build/trafficmirror
 
 #######
 # App #

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-env GOOS=linux GOARCH=amd64 go build
+GOARCH=${GOARCH:-amd64}
+
+env CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" go build


### PR DESCRIPTION
Adds linux/arm64 builds and multi-arch Docker manifests so trafficmirror can run on ARM64 Kubernetes nodes. Also removes the hardcoded amd64 Dockerfile build path.

- Current image is AMD64-only.
- ARM64 Kubernetes nodes fail with exec format error.
- This adds linux/amd64 and linux/arm64 GoReleaser builds.
- This publishes multi-arch manifests for normal tags.
- Local validation done:
    - GOOS=linux GOARCH=arm64 go build
    - docker buildx build --platform linux/arm64 ...
    - goreleaser check via Docker.
 - Runtime validation done:
    - Ran `ghcr.io/deontaljaard/trafficmirror:v2.5.4-arm64-goreleaser` (based on these changes) as a deployment in k8s